### PR TITLE
Fixed issue with missing series covers

### DIFF
--- a/app/ViewItems/PageViews/DisplayLibraryView.php
+++ b/app/ViewItems/PageViews/DisplayLibraryView.php
@@ -82,7 +82,7 @@ class DisplayLibraryView extends ViewTemplate {
 					throw new \InvalidArgumentException ("Argument (Manga Data) item at key \"{$key}\" must be of type string.");
 				}
 				
-				if (empty ($manga[$key])) {
+				if ($key !== 'path' && empty ($manga[$key])) {
 					throw new \InvalidArgumentException ("Argument (Manga Data) item at key \"{$key}\" cannot be empty.");
 				}
 			}


### PR DESCRIPTION
Fixed an issue where missing series covers on the library view would throw an exception if the cover img source was empty (which should be allowed and generate a placeholder).