### PR TITLE
Rebuilt library structure to be easier to import with

### DIFF
--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -72,9 +72,9 @@ class Config {
 		}
 		
 		$view_parameters = [];
-		$view_parameters['reader_display_style'] = $configs_dict['reader_display_style'];
+		$view_parameters['reader_display_style'] = (int) $configs_dict['reader_display_style'];
 		$view_parameters['manga_directory'] = $configs_dict['manga_directory'];
-		$view_parameters['library_view_type'] = $configs_dict['library_view_type'];
+		$view_parameters['library_view_type'] = (int) $configs_dict['library_view_type'];
 		
 		return (new \Services\View\Controller ())->
 			buildViewService ($_SERVER['DOCUMENT_ROOT'])->

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -32,6 +32,14 @@ class Config {
 	public function ajaxUpdateConfigs () {
 		$configs = json_decode ($_POST['config'], true);
 		
+		if (!empty ($configs['directory_structure'])) {
+			$q = '
+				UPDATE `server_configs` 
+				SET `config_value` = "'.$this->db->sanitize ($configs['directory_structure']).'" 
+				WHERE `config_name` = "directory_structure"';
+			$r = $this->db->query ($q);
+		}
+		
 		if (!empty ($configs['reader_display_style'])) {
 			$q = '
 				UPDATE `server_configs` 
@@ -75,6 +83,7 @@ class Config {
 		$view_parameters['reader_display_style'] = (int) $configs_dict['reader_display_style'];
 		$view_parameters['manga_directory'] = $configs_dict['manga_directory'];
 		$view_parameters['library_view_type'] = (int) $configs_dict['library_view_type'];
+		$view_parameters['directory_structure'] = $configs_dict['directory_structure'];
 		
 		return (new \Services\View\Controller ())->
 			buildViewService ($_SERVER['DOCUMENT_ROOT'])->

--- a/app/Controllers/Config.php
+++ b/app/Controllers/Config.php
@@ -56,7 +56,7 @@ class Config {
 			$r = $this->db->query ($q);
 		}
 		
-		if (!empty ($configs['manga_directory'])) {
+		if (!empty ($configs['library_view_type'])) {
 			$q = '
 				UPDATE `server_configs` 
 				SET `config_value` = '.$configs['library_view_type'].' 

--- a/app/Controllers/DisplayLibrary.php
+++ b/app/Controllers/DisplayLibrary.php
@@ -15,24 +15,25 @@ class DisplayLibrary {
 	 * Runs page process.
 	 */
 	public function begin () {
+		// Get library configs
 		$q = '
-			SELECT `config_value` FROM `server_configs`
-			WHERE `config_name` = "manga_directory"';
+			SELECT `config_name`, `config_value`
+			FROM `server_configs`
+			WHERE `config_name` IN ("manga_directory", "library_view_type")';
 		$r = $this->db->query ($q);
 		
-		$manga_directory = $r[0]['config_value'];
+		$configs = [];
+		foreach ($r as $row) {
+			$configs[$row['config_name']] = $row['config_value'];
+		}
 		
-		// Check for library view type
-		$q = '
-			SELECT `config_value` FROM `server_configs`
-			WHERE `config_name` = "library_view_type"';
-		$r = $this->db->query ($q);
+		$configs['library_view_type'] = (int) $configs['library_view_type'];
 		
-		$library_view_type = (int) $r[0]['config_value'];
-		
-		if ($library_view_type === 1) {
+		if ($configs['library_view_type'] === 1) {
 			// Display as series of covers
-			$view_parameters['manga_data'] = $this->getImagesCovers ($manga_directory);
+			$view_parameters['manga_data'] = $this->getImagesCovers (
+				$configs['manga_directory']
+			);
 			
 			return (new \Services\View\Controller ())->
 				buildViewService ($_SERVER['DOCUMENT_ROOT'])->
@@ -45,7 +46,7 @@ class DisplayLibrary {
 					],
 					$view_parameters
 				);
-		} else if ($library_view_type === 2) {
+		} else if ($configs['library_view_type'] === 2) {
 			// Display as bookcase
 			$view_parameters['manga_data'] = $this->getImagesSpines ($directory_tree);
 			$view = new DisplayLibraryBookcaseView ($view_parameters);

--- a/app/Controllers/DisplaySeries.php
+++ b/app/Controllers/DisplaySeries.php
@@ -54,7 +54,7 @@ class DisplaySeries {
 			}
 			
 			$view_parameters['volumes'][] = [
-				'link' => "/reader?cid=1",
+				'link' => "/reader?sid={$_GET['s']}&cid=1",
 				'source' => $path
 			];
 		}
@@ -75,7 +75,7 @@ class DisplaySeries {
 		foreach ($r as $row) {
 			$view_parameters['chapters'][$row['global_sort']] = [
 				'title' => "Chapter {$row['global_sort']}",
-				'link' => "\\reader?cid={$row['chapter_id']}"
+				'link' => "\\reader?sid={$_GET['s']}&cid={$row['chapter_id']}"
 			];
 		}
 		

--- a/app/Controllers/DisplaySeries.php
+++ b/app/Controllers/DisplaySeries.php
@@ -30,11 +30,13 @@ class DisplaySeries {
 		
 		// Fetch manga info by ID
 		$q = '
-			SELECT `s`.`folder_name` as `series_folder`, `v`.*
-			FROM `manga_directories_series` AS `s`
-			JOIN `manga_directories_volumes` AS `v`
-				ON `s`.`manga_id` = `v`.`manga_id`
-			WHERE `s`.`manga_id` = '.$_GET['s'];
+			SELECT `ds`.`series_id`, `ds`.`folder_name`, `cv`.`volume_id`, `iv`.`cover_ext`
+			FROM `directories_series` AS `ds`
+			JOIN `connections_volumes` AS `cv`
+				ON `ds`.`series_id` = `cv`.`series_id`
+			JOIN `images_volumes` AS `iv`
+				ON `cv`.`volume_id` = `iv`.`volume_id`
+			WHERE `ds`.`series_id` = '.$_GET['s'];
 		$r = $this->db->query ($q);
 		
 		if ($r === false) {
@@ -45,24 +47,24 @@ class DisplaySeries {
 		$view_parameters['volumes'] = [];
 		
 		foreach ($r as $v) {
-			if (empty($v['cover'])) {
+			if (empty($v['cover_ext'])) {
 				$path = '';
 			} else {
-				$path = "{$manga_directory}\\{$v['series_folder']}\\{$v['folder_name']}\\cover.{$v['cover']}";
+				$path = "{$manga_directory}\\{$v['folder_name']}\\cover.{$v['cover_ext']}";
 			}
 			
 			$view_parameters['volumes'][] = [
-				'link' => "/reader?s={$v['manga_id']}&v={$v['sort']}&c=1",
+				'link' => "/reader?cid=1",
 				'source' => $path
 			];
 		}
 		
 		$q = '
-			SELECT `v`.`sort` AS `volume_sort`, `c`.`sort` AS `chapter_sort`
-			FROM `manga_directories_volumes` AS `v`
-			JOIN `manga_directories_chapters` AS `c`
-				ON `v`.`volume_id` = `c`.`volume_id`
-			WHERE `v`.`manga_id` = '.$_GET['s'];
+			SELECT `mc`.`chapter_id`, `mc`.`global_sort`
+			FROM `metadata_chapters` AS `mc`
+			JOIN `connections_series` AS `cs`
+				ON `mc`.`chapter_id` = `cs`.`chapter_id`
+			WHERE `cs`.`series_id` = '.$_GET['s'];
 		$r = $this->db->query ($q);
 		
 		if ($r === false) {
@@ -71,11 +73,9 @@ class DisplaySeries {
 		
 		$view_parameters['chapters'] = [];
 		foreach ($r as $row) {
-			$key = "{$row['volume_sort']}{$row['chapter_sort']}";
-			
-			$view_parameters['chapters'][$key] = [
-				'title' => "Volume {$row['volume_sort']} Chapter {$row['chapter_sort']}",
-				'link' => "\\reader?s={$_GET['s']}&v={$row['volume_sort']}&c={$row['chapter_sort']}"
+			$view_parameters['chapters'][$row['global_sort']] = [
+				'title' => "Chapter {$row['global_sort']}",
+				'link' => "\\reader?cid={$row['chapter_id']}"
 			];
 		}
 		
@@ -83,8 +83,8 @@ class DisplaySeries {
 		
 		$q = '
 			SELECT `name`, `summary`, `genres`
-			FROM `manga_metadata`
-			WHERE `manga_id` = '.$_GET['s'];
+			FROM `metadata_series`
+			WHERE `series_id` = '.$_GET['s'];
 		$r = $this->db->query ($q);
 		
 		$view_parameters['summary'] = '';

--- a/app/Controllers/FirstTimeSetup.php
+++ b/app/Controllers/FirstTimeSetup.php
@@ -128,6 +128,29 @@ class FirstTimeSetup {
 		$messages[] = $this->createMessage ($r, 'manga_directories_chapters');
 		
 		$q = '
+			CREATE TABLE IF NOT EXISTS `manga_volumes` (
+				`volume_id` INT(10) UNSIGNED NOT NULL,
+				`manga_id` INT(10) UNSIGNED NOT NULL,
+				PRIMARY KEY (`volume_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'manga_volumes');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `manga_chapters` (
+				`chapter_id` INT(10) UNSIGNED NOT NULL,
+				`manga_id` INT(10) UNSIGNED NOT NULL,
+				`volume_id` INT(10) UNSIGNED NULL DEFAULT NULL,
+				PRIMARY KEY (`chapter_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'manga_chapters');
+		
+		$q = '
 			CREATE TABLE IF NOT EXISTS `manga_metadata_series` (
 				`manga_id` INT(10) NOT NULL,
 				`name` text NOT NULL,

--- a/app/Controllers/FirstTimeSetup.php
+++ b/app/Controllers/FirstTimeSetup.php
@@ -105,8 +105,7 @@ class FirstTimeSetup {
 		$q = '
 			CREATE TABLE IF NOT EXISTS `manga_directories_series` (
 				`manga_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`folder_name` VARCHAR(255) NOT NULL,
-				`series_cover` VARCHAR(20) NULL DEFAULT NULL,
+				`folder_name` VARCHAR(255) NOT NULL
 				PRIMARY KEY (`manga_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -116,29 +115,10 @@ class FirstTimeSetup {
 		$messages[] = $this->createMessage ($r, 'manga_directories_series');
 		
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_directories_volumes` (
-				`volume_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`manga_id` INT(10) NOT NULL,
-				`sort` INT(10) NOT NULL,
-				`folder_name` VARCHAR(255) NOT NULL,
-				`cover` VARCHAR(10) NULL DEFAULT NULL,
-				`spine` VARCHAR(10) NULL DEFAULT NULL,
-				`index` VARCHAR(10) NULL DEFAULT NULL,
-				PRIMARY KEY (`volume_id`)
-			)
-			COLLATE = "utf8_general_ci"
-			ENGINE = InnoDB
-			AUTO_INCREMENT = 1';
-		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_directories_volumes');
-		
-		$q = '
 			CREATE TABLE IF NOT EXISTS `manga_directories_chapters` (
 				`chapter_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`volume_id` INT(10) NOT NULL,
-				`sort` INT(10) NOT NULL,
 				`folder_name` VARCHAR(255) NOT NULL,
-				`is_archive` TINYINT(1) NOT NULL,
+				`is_archive` TINYINT(1) NOT NULL
 				PRIMARY KEY (`chapter_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -148,19 +128,68 @@ class FirstTimeSetup {
 		$messages[] = $this->createMessage ($r, 'manga_directories_chapters');
 		
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_metadata` (
-				`manga_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`name` VARCHAR(255) NOT NULL,
-				`name_original` VARCHAR(255) NULL DEFAULT NULL,
-				`summary` VARCHAR(2000) NULL DEFAULT NULL,
-				`genres` VARCHAR(2000) NULL DEFAULT NULL,
+			CREATE TABLE IF NOT EXISTS `manga_metadata_series` (
+				`manga_id` INT(10) NOT NULL,
+				`name` text NOT NULL,
+				`name_original` text NULL DEFAULT NULL,
+				`summary` text NULL DEFAULT NULL,
+				`genres` text NULL DEFAULT NULL,
 				PRIMARY KEY (`manga_id`)
 			)
 			COLLATE = "utf8_general_ci"
 			ENGINE = InnoDB
 			AUTO_INCREMENT = 1';
 		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_metadata');
+		$messages[] = $this->createMessage ($r, 'manga_metadata_series');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `manga_metadata_volumes` (
+				`volume_id` INT(10) NOT NULL,
+				`sort` INT(10) NOT NULL,
+				`volume_name` text NULL DEFAULT NULL
+				PRIMARY KEY (`volume_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'manga_metadata_volumes');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `manga_metadata_chapters` (
+				`chapter_id` INT(10) NOT NULL,
+				`sort` INT(10) NOT NULL,
+				`volume_id` INT(10) NULL DEFAULT NULL,
+				`chapter_name` text NULL DEFAULT NULL
+				PRIMARY KEY (`chapter_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'manga_metadata_chapters');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `manga_images_series` (
+				`manga_id` INT(10) NOT NULL,
+				`cover_ext` VARCHAR(10) NULL DEFAULT NULL
+				PRIMARY KEY (`manga_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'manga_images_series');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `manga_images_volumes` (
+				`volume_id` INT(10) NOT NULL,
+				`cover_ext` VARCHAR(10) NULL DEFAULT NULL,
+				`index_ext` VARCHAR(10) NULL DEFAULT NULL,
+				`spine_ext` VARCHAR(10) NULL DEFAULT NULL
+				PRIMARY KEY (`volume_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'manga_images_volumes');
 		
 		$q = '
 			CREATE TABLE IF NOT EXISTS `server_configs` (

--- a/app/Controllers/FirstTimeSetup.php
+++ b/app/Controllers/FirstTimeSetup.php
@@ -102,108 +102,88 @@ class FirstTimeSetup {
 		$q = 'use `server`';
 		$r = $db->query ($q);
 		
+		// Series tables
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_directories_series` (
-				`manga_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`folder_name` VARCHAR(255) NOT NULL,
-				PRIMARY KEY (`manga_id`)
-			)
-			COLLATE = "utf8_general_ci"
-			ENGINE = InnoDB
-			AUTO_INCREMENT = 1';
-		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_directories_series');
-		
-		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_directories_chapters` (
-				`chapter_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`folder_name` VARCHAR(255) NOT NULL,
-				`is_archive` TINYINT(1) NOT NULL,
-				PRIMARY KEY (`chapter_id`)
-			)
-			COLLATE = "utf8_general_ci"
-			ENGINE = InnoDB
-			AUTO_INCREMENT = 1';
-		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_directories_chapters');
-		
-		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_volumes` (
-				`volume_id` INT(10) UNSIGNED NOT NULL,
-				`manga_id` INT(10) UNSIGNED NOT NULL,
-				PRIMARY KEY (`volume_id`)
-			)
-			COLLATE = "utf8_general_ci"
-			ENGINE = InnoDB';
-		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_volumes');
-		
-		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_chapters` (
-				`chapter_id` INT(10) UNSIGNED NOT NULL,
-				`manga_id` INT(10) UNSIGNED NOT NULL,
-				`volume_id` INT(10) UNSIGNED NULL DEFAULT NULL,
-				PRIMARY KEY (`chapter_id`)
-			)
-			COLLATE = "utf8_general_ci"
-			ENGINE = InnoDB';
-		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_chapters');
-		
-		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_metadata_series` (
-				`manga_id` INT(10) NOT NULL,
+			CREATE TABLE IF NOT EXISTS `metadata_series` (
+				`series_id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
 				`name` text NOT NULL,
 				`name_original` text NULL DEFAULT NULL,
 				`summary` text NULL DEFAULT NULL,
 				`genres` text NULL DEFAULT NULL,
-				PRIMARY KEY (`manga_id`)
+				PRIMARY KEY (`series_id`)
 			)
 			COLLATE = "utf8_general_ci"
 			ENGINE = InnoDB
 			AUTO_INCREMENT = 1';
 		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_metadata_series');
+		$messages[] = $this->createMessage ($r, 'metadata_series');
 		
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_metadata_volumes` (
-				`volume_id` INT(10) NOT NULL,
-				`sort` INT(10) NOT NULL,
-				`volume_name` text NULL DEFAULT NULL,
-				PRIMARY KEY (`volume_id`)
+			CREATE TABLE IF NOT EXISTS `directories_series` (
+				`series_id` INT(10) UNSIGNED NOT NULL,
+				`folder_name` VARCHAR(255) NOT NULL,
+				PRIMARY KEY (`series_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB
+			AUTO_INCREMENT = 1';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'directories_series');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `images_series` (
+				`series_id` INT(10) UNSIGNED NOT NULL,
+				`cover_ext` VARCHAR(10) NULL DEFAULT NULL,
+				PRIMARY KEY (`series_id`)
 			)
 			COLLATE = "utf8_general_ci"
 			ENGINE = InnoDB';
 		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_metadata_volumes');
+		$messages[] = $this->createMessage ($r, 'images_series');
+		
+		// Chapter tables
+		$q = '
+			CREATE TABLE IF NOT EXISTS `metadata_chapters` (
+				`chapter_id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+				`global_sort` INT(10) UNSIGNED NOT NULL,
+				`chapter_name` text NULL DEFAULT NULL,
+				PRIMARY KEY (`chapter_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB
+			AUTO_INCREMENT = 1';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'metadata_chapters');
 		
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_metadata_chapters` (
-				`chapter_id` INT(10) NOT NULL,
-				`sort` INT(10) NOT NULL,
-				`volume_id` INT(10) NULL DEFAULT NULL,
-				`chapter_name` text NULL DEFAULT NULL,
+			CREATE TABLE IF NOT EXISTS `directories_chapters` (
+				`chapter_id` INT(10) UNSIGNED NOT NULL,
+				`folder_name` VARCHAR(255) NOT NULL,
+				`is_archive` TINYINT(1) UNSIGNED NOT NULL,
 				PRIMARY KEY (`chapter_id`)
 			)
 			COLLATE = "utf8_general_ci"
 			ENGINE = InnoDB';
 		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_metadata_chapters');
+		$messages[] = $this->createMessage ($r, 'directories_chapters');
 		
+		// Volume tables
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_images_series` (
-				`manga_id` INT(10) NOT NULL,
-				`cover_ext` VARCHAR(10) NULL DEFAULT NULL,
-				PRIMARY KEY (`manga_id`)
+			CREATE TABLE IF NOT EXISTS `metadata_volumes` (
+				`volume_id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+				`sort` INT(10) UNSIGNED NOT NULL,
+				`volume_name` text NULL DEFAULT NULL,
+				PRIMARY KEY (`volume_id`)
 			)
 			COLLATE = "utf8_general_ci"
-			ENGINE = InnoDB';
+			ENGINE = InnoDB
+			AUTO_INCREMENT = 1';
 		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_images_series');
+		$messages[] = $this->createMessage ($r, 'metadata_volumes');
 		
 		$q = '
-			CREATE TABLE IF NOT EXISTS `manga_images_volumes` (
-				`volume_id` INT(10) NOT NULL,
+			CREATE TABLE IF NOT EXISTS `images_volumes` (
+				`volume_id` INT(10) UNSIGNED NOT NULL,
 				`cover_ext` VARCHAR(10) NULL DEFAULT NULL,
 				`index_ext` VARCHAR(10) NULL DEFAULT NULL,
 				`spine_ext` VARCHAR(10) NULL DEFAULT NULL,
@@ -212,8 +192,43 @@ class FirstTimeSetup {
 			COLLATE = "utf8_general_ci"
 			ENGINE = InnoDB';
 		$r = $db->query ($q);
-		$messages[] = $this->createMessage ($r, 'manga_images_volumes');
+		$messages[] = $this->createMessage ($r, 'images_volumes');
 		
+		// Connections tables
+		$q = '
+			CREATE TABLE IF NOT EXISTS `connections_series` (
+				`chapter_id` INT(10) UNSIGNED NOT NULL,
+				`series_id` INT(10) UNSIGNED NOT NULL,
+				PRIMARY KEY (`chapter_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'connections_series');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `connections_volumes` (
+				`volume_id` INT(10) UNSIGNED NOT NULL,
+				`series_id` INT(10) UNSIGNED NOT NULL,
+				PRIMARY KEY (`volume_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'connections_volumes');
+		
+		$q = '
+			CREATE TABLE IF NOT EXISTS `connections_chapters` (
+				`chapter_id` INT(10) UNSIGNED NOT NULL,
+				`volume_id` INT(10) UNSIGNED NULL,
+				PRIMARY KEY (`chapter_id`)
+			)
+			COLLATE = "utf8_general_ci"
+			ENGINE = InnoDB';
+		$r = $db->query ($q);
+		$messages[] = $this->createMessage ($r, 'connections_chapters');
+		
+		// Other tables
 		$q = '
 			CREATE TABLE IF NOT EXISTS `server_configs` (
 				`config_id` INT(11) NOT NULL AUTO_INCREMENT,

--- a/app/Controllers/FirstTimeSetup.php
+++ b/app/Controllers/FirstTimeSetup.php
@@ -195,7 +195,7 @@ class FirstTimeSetup {
 			CREATE TABLE IF NOT EXISTS `server_configs` (
 				`config_id` INT(11) NOT NULL AUTO_INCREMENT,
 				`config_name` VARCHAR(255) NOT NULL,
-				`config_value` VARCHAR(255) NOT NULL,
+				`config_value` VARCHAR(255) NULL DEFAULT NULL,
 				PRIMARY KEY (`config_id`),
 				UNIQUE INDEX `config_name` (`config_name`)
 			)
@@ -261,6 +261,7 @@ class FirstTimeSetup {
 			INSERT INTO `server_configs`
 				(`config_name`, `config_value`)
 			VALUES
+				("directory_structure", ""),
 				("reader_display_style", 2),
 				("manga_directory", ""),
 				("library_view_type", 1)';

--- a/app/Controllers/FirstTimeSetup.php
+++ b/app/Controllers/FirstTimeSetup.php
@@ -105,7 +105,7 @@ class FirstTimeSetup {
 		$q = '
 			CREATE TABLE IF NOT EXISTS `manga_directories_series` (
 				`manga_id` INT(10) NOT NULL AUTO_INCREMENT,
-				`folder_name` VARCHAR(255) NOT NULL
+				`folder_name` VARCHAR(255) NOT NULL,
 				PRIMARY KEY (`manga_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -118,7 +118,7 @@ class FirstTimeSetup {
 			CREATE TABLE IF NOT EXISTS `manga_directories_chapters` (
 				`chapter_id` INT(10) NOT NULL AUTO_INCREMENT,
 				`folder_name` VARCHAR(255) NOT NULL,
-				`is_archive` TINYINT(1) NOT NULL
+				`is_archive` TINYINT(1) NOT NULL,
 				PRIMARY KEY (`chapter_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -146,7 +146,7 @@ class FirstTimeSetup {
 			CREATE TABLE IF NOT EXISTS `manga_metadata_volumes` (
 				`volume_id` INT(10) NOT NULL,
 				`sort` INT(10) NOT NULL,
-				`volume_name` text NULL DEFAULT NULL
+				`volume_name` text NULL DEFAULT NULL,
 				PRIMARY KEY (`volume_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -159,7 +159,7 @@ class FirstTimeSetup {
 				`chapter_id` INT(10) NOT NULL,
 				`sort` INT(10) NOT NULL,
 				`volume_id` INT(10) NULL DEFAULT NULL,
-				`chapter_name` text NULL DEFAULT NULL
+				`chapter_name` text NULL DEFAULT NULL,
 				PRIMARY KEY (`chapter_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -170,7 +170,7 @@ class FirstTimeSetup {
 		$q = '
 			CREATE TABLE IF NOT EXISTS `manga_images_series` (
 				`manga_id` INT(10) NOT NULL,
-				`cover_ext` VARCHAR(10) NULL DEFAULT NULL
+				`cover_ext` VARCHAR(10) NULL DEFAULT NULL,
 				PRIMARY KEY (`manga_id`)
 			)
 			COLLATE = "utf8_general_ci"
@@ -183,7 +183,7 @@ class FirstTimeSetup {
 				`volume_id` INT(10) NOT NULL,
 				`cover_ext` VARCHAR(10) NULL DEFAULT NULL,
 				`index_ext` VARCHAR(10) NULL DEFAULT NULL,
-				`spine_ext` VARCHAR(10) NULL DEFAULT NULL
+				`spine_ext` VARCHAR(10) NULL DEFAULT NULL,
 				PRIMARY KEY (`volume_id`)
 			)
 			COLLATE = "utf8_general_ci"

--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -13,9 +13,9 @@ class Home {
 		// Get number of series
 		$q = '
 			SELECT
-				(SELECT COUNT(*) FROM `manga_directories_series`) AS `series`,
-				(SELECT COUNT(*) FROM `manga_directories_volumes`) AS `volumes`,
-				(SELECT COUNT(*) FROM `manga_directories_chapters`) AS `chapters`';
+				(SELECT COUNT(*) FROM `manga_metadata_series`) AS `series`,
+				(SELECT COUNT(*) FROM `manga_metadata_volumes`) AS `volumes`,
+				(SELECT COUNT(*) FROM `manga_metadata_chapters`) AS `chapters`';
 		$r = $db->query ($q);
 		
 		$view_parameters['box_contents'] = [

--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -13,9 +13,9 @@ class Home {
 		// Get number of series
 		$q = '
 			SELECT
-				(SELECT COUNT(*) FROM `manga_metadata_series`) AS `series`,
-				(SELECT COUNT(*) FROM `manga_metadata_volumes`) AS `volumes`,
-				(SELECT COUNT(*) FROM `manga_metadata_chapters`) AS `chapters`';
+				(SELECT COUNT(*) FROM `metadata_series`) AS `series`,
+				(SELECT COUNT(*) FROM `metadata_volumes`) AS `volumes`,
+				(SELECT COUNT(*) FROM `metadata_chapters`) AS `chapters`';
 		$r = $db->query ($q);
 		
 		$view_parameters['box_contents'] = [

--- a/app/Core/Database.php
+++ b/app/Core/Database.php
@@ -85,6 +85,10 @@ class Database {
 		return $result;
 	}
 	
+	public function getLastIndex () {
+		return $this->connection->insert_id;
+	}
+	
 	/**
 	 * Sanitizes the given string.
 	 * 

--- a/app/Services/View/Data/Config.php
+++ b/app/Services/View/Data/Config.php
@@ -8,10 +8,12 @@ namespace Services\View\Data;
  */
 class Config implements IViewData {
 	/**
+	 * @var string $directory_structure  structure of files in directory
 	 * @var int    $library_view_type    library view type
 	 * @var string $manga_directory      manga directory setting
 	 * @var int    $reader_display_style reader display style setting
 	 */
+	private $directory_structure;
 	private $library_view_type;
 	private $manga_directory;
 	private $reader_display_style;
@@ -19,6 +21,7 @@ class Config implements IViewData {
 	/**
 	 * Constructor for data object.
 	 * 
+	 * @param string $directory_structure  structure of files in directory
 	 * @param int    $library_view_type    library view type
 	 * @param string $manga_directory      manga directory setting
 	 * @param int    $reader_display_style reader display style setting
@@ -26,13 +29,26 @@ class Config implements IViewData {
 	 * @throws TypeError on invalid parameter type
 	 */
 	public function __construct (
+		string $directory_structure,
 		int $library_view_type,
 		string $manga_directory,
 		int $reader_display_style
 	) {
+		$this->setDirectoryStructure ($directory_structure);
 		$this->setLibraryViewType ($library_view_type);
 		$this->setMangaDirectory ($manga_directory);
 		$this->setReaderDisplayStyle ($reader_display_style);
+	}
+	
+	/**
+	 * Gets the manga file directory structure setting.
+	 * 
+	 * @return string structure of files in directory
+	 * 
+	 * @throws TypeError on non-string return
+	 */
+	public function getDirectoryStructure () : string {
+		return $this->directory_structure;
 	}
 	
 	/**
@@ -77,6 +93,17 @@ class Config implements IViewData {
 	 */
 	public function getViewName () : string {
 		return 'Config';
+	}
+	
+	/**
+	 * Sets the manga directory structure setting.
+	 * 
+	 * @param string $directory_structure structure of files in directory
+	 * 
+	 * @throws TypeError on non-string config value
+	 */
+	private function setDirectoryStructure (string $directory_structure) {
+		$this->directory_structure = $directory_structure;
 	}
 	
 	/**

--- a/app/ViewItems/HTML/Config.php
+++ b/app/ViewItems/HTML/Config.php
@@ -20,6 +20,10 @@
 					<input id="manga_directory" value="<?php echo $view->getMangaDirectory (); ?>" type="text" autocomplete="off" />
 				</div>
 				<div class="config_item">
+					<label>Directory structure</label>
+					<input id="directory_structure" value="<?php echo $view->getDirectoryStructure  (); ?>" type="text" autocomplete="off" />
+				</div>
+				<div class="config_item">
 					<label>Library Display Style</label>
 					<select id="library_view_type" autocomplete="off">
 						<option value="1" <?php echo $view->getLibraryViewType () === 1 ? 'selected' : ''; ?>>

--- a/app/ViewItems/HTML/ReaderStrip.php
+++ b/app/ViewItems/HTML/ReaderStrip.php
@@ -7,7 +7,7 @@
 	<?php
 	} 
 	
-	if ($view->getNextChapterLink () !== null) { ?>
+	if (!empty ($view->getNextChapterLink ())) { ?>
 		<div class="continue_btn">
 			<a href="<?php echo $view->getNextChapterLink (); ?>">
 				Continue to next chaper.

--- a/app/ViewItems/JS/Config.js
+++ b/app/ViewItems/JS/Config.js
@@ -20,6 +20,14 @@ $(window).ready (function () {
 		});
 	}
 	
+	$("#directory_structure").change (function () {
+		var config = {
+			"directory_structure" : $("#directory_structure").val ()
+		};
+		
+		ajaxUpdateConfigs (config, $(this));
+	});
+	
 	$("#reader_display_style").change (function () {
 		var config = {
 			"reader_display_style" : $("#reader_display_style").val ()


### PR DESCRIPTION
Update the database structure to use volume as an item of metadata. Desynced miscellaneous items, such as images, from the directory structure of the actual manga so they can also be treated as metadata. This should make it easier for people to import directly into the software in the format that content most likely appears as (in the form of single chapter releases with no accompanying metadata. 

Also added metadata file read (natively from HDoujin Downloader) to populate before searching the web.